### PR TITLE
fix nocontrol read counts when there are no positive control sequences

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# optimotu_targets 4.1.1
+
+- Fixed a bug which caused an error when using positive control sequences.
+
 # optimotu_targets 4.1.0
 
 - Detection of spike sequences is now optional, and an option is also included

--- a/scripts/010_load_options.R
+++ b/scripts/010_load_options.R
@@ -319,7 +319,7 @@ spike_file <- NULL
 do_pos_control <- FALSE
 pos_control_file <- NULL
 spike_read_counts <- nospike_read_counts <- control_read_counts <-
-  noncontrol_read_counts <- tibble::tibble(sample_key = character())
+  nocontrol_read_counts <- tibble::tibble(sample_key = character())
 if (!is.null(pipeline_options$control)) {
   checkmate::assert_list(pipeline_options$control)
   pipeline_options$control <- unnest_yaml_list(pipeline_options$control)


### PR DESCRIPTION
Fixed a bug which caused an error when using positive control sequences.